### PR TITLE
fix: correct spread operator syntax for urlParamsObject in fetchAPI f…

### DIFF
--- a/src/utils/fetchApi.ts
+++ b/src/utils/fetchApi.ts
@@ -29,7 +29,7 @@ export default async function fetchAPI({
     const populateRequest = isPopulate ? { pLevel: '5' } : {}
 
     const mergedParams = {
-      ..?.urlParamsObject,
+      ...urlParamsObject,
       ...populateRequest,
     }
 


### PR DESCRIPTION
…unction